### PR TITLE
removing the tls_config and bearer_token_file properties

### DIFF
--- a/prometheus-ephemeral/prometheus-ephemeral.yml
+++ b/prometheus-ephemeral/prometheus-ephemeral.yml
@@ -117,9 +117,6 @@ objects:
               namespaces:
                 names:
                 - '{{MY_POD_NAMESPACE}}'
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
             relabel_configs:
             - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
               action: keep
@@ -152,9 +149,6 @@ objects:
               namespaces:
                 names:
                 - '{{MY_POD_NAMESPACE}}'
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
             relabel_configs:
             - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
               action: keep
@@ -195,9 +189,6 @@ objects:
               namespaces:
                 names:
                 - '{{MY_POD_NAMESPACE}}'
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
             metrics_path: /probe
             params:
               module: [http_2xx]


### PR DESCRIPTION
The `tls_config` and `bearer_token_file` properties are wrongly indented in the scrape configuration. They are set on `job` level rather than `kubernetes_sd_configs` level (where they are not needed because they already are the default).

The current configuration has the effect that application metrics are being accessed using the service accounts' Kubernetes API token (instead of an application-specific token), which may lead to such errors:
```
com.auth0.jwt.exceptions.SignatureVerificationException: The Token's Signature resulted invalid when verified using the Algorithm: SHA256withRSA
```
and:
```
Invalid JWT Signature, Request Headers:, {host:10.128.6.240:9080}, {user-agent:Prometheus/2.15.2}
```

One way to correct this would be to indent the two properties into the `kubernetes_sd_configs`, but according to the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config), discovery is automatically done by default:
```
# The API server addresses. If left empty, Prometheus is assumed to run inside
# of the cluster and will discover API servers automatically and use the pod's
# CA certificate and bearer token file at /var/run/secrets/kubernetes.io/serviceaccount/.
```
